### PR TITLE
Potential fix for code scanning alert no. 30: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "solid-js": "^1.9.11",
     "tailwind-merge": "^3.4.1",
     "tailwindcss": "^3.4.19",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "string-strip-html": "^13.5.3"
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { stripHtml } from "string-strip-html"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -14,7 +15,7 @@ export function formatDate(date: Date) {
 }
 
 export function readingTime(html: string) {
-  const textOnly = html.replace(/<[^>]+>/g, "")
+  const textOnly = stripHtml(html).result
   const wordCount = textOnly.split(/\s+/).length
   const readingTimeMinutes = ((wordCount / 200) + 1).toFixed()
   return `${readingTimeMinutes} min read`


### PR DESCRIPTION
Potential fix for [https://github.com/andylang8445/andylang8445.github.io/security/code-scanning/30](https://github.com/andylang8445/andylang8445.github.io/security/code-scanning/30)

In general, the safest fix is to avoid hand‑rolled regex sanitization and instead use a well‑maintained HTML parser/stripper library that is designed to handle malformed and nested tags correctly. For this particular case, we need only plain text for word counting, so we can use a library that converts HTML to text (e.g. `string-strip-html`) and then count words on the result. This avoids incomplete multi‑character sanitization and ensures that no stray `<script` or other tag fragments remain.

Concretely, in `src/lib/utils.ts`, update the `readingTime` function (lines 16–21). Replace the current `const textOnly = html.replace(/<[^>]+>/g, "")` with a call to a robust HTML stripper. We can import `stripHtml` from the `string-strip-html` package at the top of the file, then use `stripHtml(html).result` to obtain clean text. The rest of the logic (splitting on whitespace, computing minutes, and returning `"X min read"`) remains unchanged, preserving existing functionality while hardening sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
