### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -1,5 +1,8 @@
 name: "Docker Security Scan"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/andylang8445/andylang8445.github.io/security/code-scanning/32](https://github.com/andylang8445/andylang8445.github.io/security/code-scanning/32)

To fix the problem, explicitly declare restricted `permissions` for the workflow so that the `GITHUB_TOKEN` has only the minimum necessary rights. For this job, reading repository contents is sufficient, so `contents: read` at the workflow or job level is appropriate.

The best fix without changing functionality is to add a root-level `permissions` block (applies to all jobs) near the top of `.github/workflows/docker-scan.yml`, alongside `name` and `on`. For example:

```yaml
name: "Docker Security Scan"

permissions:
  contents: read
  # packages: read   # only if needed for private registries

on:
  ...
```

This leaves the job steps unchanged, still allowing `actions/checkout` to read the repo while preventing unintended write operations. No imports or additional methods are needed; only YAML configuration changes within this workflow file are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
